### PR TITLE
Remove "support" key from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,6 @@
     "description": "A skeleton repository for my packages",
     "keywords": ["php", "skeleton", "package"],
     "license": "MIT",
-    "support": {
-        "issues": "https://github.com/nunomaduro/skeleton-php/issues",
-        "source": "https://github.com/nunomaduro/skeleton-php"
-    },
     "authors": [
         {
             "name": "Nuno Maduro",


### PR DESCRIPTION
When using GitHub, the `support` links are automatically filled in on packagist.org. So unless you're publishing this package (or anything that derives from it), you don't need the key at all.