### PR TITLE
Changes Rector to be up to PHP 8.2

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -17,7 +17,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_82,
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
         SetList::EARLY_RETURN,


### PR DESCRIPTION
This PR changes Rector to use `LevelSetList::UP_TO_PHP_82` (was `LevelSetList::UP_TO_PHP_81`), as `composer.json` is set as `^8.2.0` for PHP.