### PR TITLE
prestissimo is no longer needed with composer 2

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         extensions: dom, mbstring, zip
-        tools: prestissimo
         coverage: pcov
 
     - name: Get Composer cache directory


### PR DESCRIPTION
Having prestissimo enabled shows this error when running the GH actions:

```
==> Setup Tools
✓ composer Added composer 2.5.8
Warning:  Skipping prestissimo, as it does not support Composer . Specify composer:v1 in tools to use prestissimo
✗ prestissimo Skipped
```

As of composer 2 (some time ago now), prestissimo is no longer needed. See discussion in https://github.com/hirak/prestissimo/issues/233

This PR simply removes it.