### PR TITLE
Fix Rector, add Architecture test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
 - Adds first version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,28 +20,35 @@ Please review these guidelines before submitting any pull requests.
 ## Setup
 
 Clone your fork, then install the dev dependencies:
+
 ```bash
 composer install
 ```
+
 ## Lint
 
 Lint your code:
+
 ```bash
 composer lint
 ```
+
 ## Tests
 
 Run all tests:
+
 ```bash
 composer test
 ```
 
 Check types:
+
 ```bash
 composer test:types
 ```
 
 Unit tests:
+
 ```bash
 composer test:unit
 ```

--- a/README.md
+++ b/README.md
@@ -20,26 +20,31 @@ composer create-project nunomaduro/skeleton-php --prefer-source PackageName
 ```
 
 🧹 Keep a modern codebase with **Pint**:
+
 ```bash
 composer lint
 ```
 
 ✅ Run refactors using **Rector**
+
 ```bash
 composer refacto
 ```
 
 ⚗️ Run static analysis using **PHPStan**:
+
 ```bash
 composer test:types
 ```
 
 ✅ Run unit tests using **PEST**
+
 ```bash
 composer test:unit
 ```
 
 🚀 Run the entire test suite:
+
 ```bash
 composer test
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/pint": "^1.13.7",
         "pestphp/pest": "^2.28.1",
         "phpstan/phpstan": "^1.10.50",
-        "rector/rector": "^0.18.13",
+        "rector/rector": "^0.19.5",
         "symfony/var-dumper": "^6.4.0|^7.0.0"
     },
     "autoload": {

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,0 +1,9 @@
+<?php
+
+arch('it does not use debug functions')
+    ->expect(['dd', 'ddd', 'dump', 'var_dump', 'print_r', 'ray'])
+    ->each->not->toBeUsed();
+
+arch('it uses Strict Types')
+    ->expect('NunoMaduro\SkeletonPhp')
+    ->toUseStrictTypes();


### PR DESCRIPTION
Hi Nuno,

This PR upgrades Rector to fix the following error:

<img src="https://github.com/nunomaduro/skeleton-php/assets/79267265/4878c646-e0c0-4617-9633-e59ba7501d86" width="500"/>

In addition, I included an ArchTest to showcase and promote Pest features.

I noticed Markdowns were failing lint, so I fix them.

[MD022 - Headings should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md022.md)
[MD031 - Fenced code blocks should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md031.md)

Greetings,

Dan
