### PR TITLE
Fix missing files when creating new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package provides a wonderful **PHP Skeleton** to start building your next p
 ⚡️ Create your package using [Composer](https://getcomposer.org):
 
 ```bash
-composer create-project nunomaduro/skeleton-php --prefer-dist PackageName
+composer create-project nunomaduro/skeleton-php --prefer-source --remove-vcs PackageName
 ```
 
 🧹 Keep a modern codebase with **Pint**:


### PR DESCRIPTION
The readme `composer create-project` command doesn't appear to include every file I would expect:

<img width="236" height="119" alt="Screenshot 2025-10-22 at 10 32 50" src="https://github.com/user-attachments/assets/ce868d51-f8ec-44f4-bcf4-7c3a627de2b9" />

I believe the issue is the `.gitattributes` file has `export-ignore` declared for the missing files, so along with `--prefer-dist`, the files aren't exported to the archive.

I changed the command to `--prefer-source`, and `--remove-vcs` (to remove `.git`), and the results are what I expect:

<img width="239" height="406" alt="Screenshot 2025-10-22 at 10 32 57" src="https://github.com/user-attachments/assets/bb90fafe-0825-462a-a5c5-722b66207237" />
