### PR TITLE
Fix `strictBooleans` deprecated.

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -19,6 +19,6 @@ return RectorConfig::configure()
         typeDeclarations: true,
         privatization: true,
         earlyReturn: true,
-        strictBooleans: true,
+        codingStyle: true,
     )
     ->withPhpSets();


### PR DESCRIPTION
Fixes the warning I got after installation and running `composer refactor`

```
[WARNING] The "strictBooleans" set is deprecated as mostly risky and not practical. Remove it from withPreparedSets()  
           method and use "codeQuality" and "codingStyle" sets instead. They already contain more granular and stable   
           rules on same note.          
```